### PR TITLE
Change .transfer() to .call(), implement checks-effects-interaction

### DIFF
--- a/Contracts/package-lock.json
+++ b/Contracts/package-lock.json
@@ -5783,7 +5783,8 @@
         },
         "@ethersproject/hash": {
           "version": "5.0.10",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+          "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5891,7 +5892,8 @@
         },
         "@ethersproject/transactions": {
           "version": "5.0.9",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+          "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10945,7 +10947,8 @@
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -11510,7 +11513,8 @@
         },
         "normalize-url": {
           "version": "4.5.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
           "dev": true,
           "optional": true
         },
@@ -11877,7 +11881,8 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "path-to-regexp": {
@@ -13175,7 +13180,8 @@
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
           "requires": {


### PR DESCRIPTION
The takeMoney() and _pay() functions should implement checks-effects-interaction patterns to prevent reentrancy rather than relying on gas limiting via the .transfer() function. Instances of .transfer() should also be reimplemented as .call() to ensure EIP 1884 compliance.

Note: 1884 may not even be implemented on Moonriver, but this should still be implemented in the interest of wider EVM compatibility. 